### PR TITLE
listen: not-wake-up: increase the random value's range

### DIFF
--- a/precise/pocketsphinx/scripts/listen.py
+++ b/precise/pocketsphinx/scripts/listen.py
@@ -41,7 +41,7 @@ usage = '''
         Samples between inferences
 '''
 
-session_id, chunk_num = '%03d' % randint(0, 999), 0
+session_id, chunk_num = '%09d' % randint(0, 999999999), 0
 
 
 def main():

--- a/precise/scripts/listen.py
+++ b/precise/scripts/listen.py
@@ -43,7 +43,7 @@ usage = '''
         Prefix for saved filenames
 '''
 
-session_id, chunk_num = '%03d' % randint(0, 999), 0
+session_id, chunk_num = '%09d' % randint(0, 999999999), 0
 
 
 def main():


### PR DESCRIPTION
the old range is too narrow and therefore make data override often happen.

Signed-off-by: Wu Zhangjin <wuzhangjin@gmail.com>