### PR TITLE
Removed redundant code

### DIFF
--- a/precise/scripts/train_optimize.py
+++ b/precise/scripts/train_optimize.py
@@ -82,7 +82,7 @@ class OptimizeTrainer(Trainer):
             print("\n= %d = (example #%d)" % (i + 1, len(self.bb.get_data()["examples"]) + 1))
 
             params = ModelParams(
-                recurrent_units=self.bb.randint("units", 1, 100, guess=50),
+                recurrent_units=self.bb.randint("units", 1, 70, guess=50),
                 dropout=self.bb.uniform("dropout", 0.1, 0.9, guess=0.6),
                 extra_metrics=self.args.extra_metrics,
                 skip_acc=self.args.no_validation,

--- a/precise/scripts/train_optimize.py
+++ b/precise/scripts/train_optimize.py
@@ -119,7 +119,6 @@ class OptimizeTrainer(Trainer):
                 "fitness": fitness
             })
 
-            print(false_positives)
             print("False positive: ", false_positives * 100, "%")
 
             self.bb.maximize(fitness)


### PR DESCRIPTION
removed a redundant line of code. print("False positive: ", false_positives * 100, "%") is already being printed so print(false_positives) isn't needed.