### PR TITLE
Modify audio playing command in play_audio() for Darwin

### DIFF
--- a/precise/util.py
+++ b/precise/util.py
@@ -74,8 +74,10 @@ def play_audio(filename: str):
     import platform
     from subprocess import Popen
 
-    player = 'play' if platform.system() == 'Darwin' else 'aplay'
-    Popen([player, '-q', filename])
+    if platform.system() == 'Darwin':
+        Popen(['afplay', filename])
+    else:
+        Popen(['aplay', '-q', filename])
 
 
 def activate_notify():


### PR DESCRIPTION
## Overview

I executed command below to test my custom model according to [this tutorial](https://github.com/MycroftAI/mycroft-precise/wiki/Training-your-own-wake-word#how-to-train-your-own-wake-word).

```
$precise-listen mymodel.net
```

I got this error.

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/Users/yoshiakiyamada/.pyenv/versions/3.6.2/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/Users/yoshiakiyamada/.pyenv/versions/3.6.2/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/yoshiakiyamada/git/mycroft-precise/runner/precise_runner/runner.py", line 243, in _handle_predictions
    self.on_activation()
  File "/Users/yoshiakiyamada/git/mycroft-precise/precise/scripts/listen.py", line 66, in on_activation
    activate_notify()
  File "/Users/yoshiakiyamada/git/mycroft-precise/precise/util.py", line 85, in activate_notify
    play_audio(audio)
  File "/Users/yoshiakiyamada/git/mycroft-precise/precise/util.py", line 78, in play_audio
    Popen([player, '-q', filename])
  File "/Users/yoshiakiyamada/.pyenv/versions/3.6.2/lib/python3.6/subprocess.py", line 707, in __init__
    restore_signals, start_new_session)
  File "/Users/yoshiakiyamada/.pyenv/versions/3.6.2/lib/python3.6/subprocess.py", line 1333, in _execute_child
    raise child_exception_type(errno_num, err_msg)
FileNotFoundError: [Errno 2] No such file or directory: 'play'
```

This happens because this script try to run `play` command through `popen`, but Darwin doesn't have `play` command (Is it right? at least, my Mac doesn't have it and can't find anywhere).
https://github.com/MycroftAI/mycroft-precise/blob/dev/precise/util.py#L77

So I replace it to use [`afplay`](https://ss64.com/osx/afplay.html) command, it's the command of Darwin to play audio file.

Mac OS Version: 10.15.2 (Catalina)